### PR TITLE
fix more tests for markup/markdown/katex tests

### DIFF
--- a/modules/markup/html_test.go
+++ b/modules/markup/html_test.go
@@ -7,6 +7,7 @@ package markup_test
 import (
 	"context"
 	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -32,6 +33,7 @@ func TestMain(m *testing.M) {
 	if err := git.InitSimple(context.Background()); err != nil {
 		log.Fatal("git init failed, err: %v", err)
 	}
+	os.Exit(m.Run())
 }
 
 func TestRender_Commits(t *testing.T) {
@@ -336,7 +338,7 @@ func TestRender_emoji(t *testing.T) {
 		`<p>Some text with <span class="emoji" aria-label="grinning face with smiling eyes">😄</span><span class="emoji" aria-label="grinning face with smiling eyes">😄</span> 2 emoji next to each other</p>`)
 	test(
 		"😎🤪🔐🤑❓",
-		`<p><span class="emoji" aria-label="smiling face with sunglasses">😎</span><span class="emoji" aria-label="zany face">🤪</span><span class="emoji" aria-label="locked with key">🔐</span><span class="emoji" aria-label="money-mouth face">🤑</span><span class="emoji" aria-label="question mark">❓</span></p>`)
+		`<p><span class="emoji" aria-label="smiling face with sunglasses">😎</span><span class="emoji" aria-label="zany face">🤪</span><span class="emoji" aria-label="locked with key">🔐</span><span class="emoji" aria-label="money-mouth face">🤑</span><span class="emoji" aria-label="red question mark">❓</span></p>`)
 
 	// should match nothing
 	test(

--- a/modules/markup/markdown/meta.go
+++ b/modules/markup/markdown/meta.go
@@ -88,7 +88,9 @@ func ExtractMetadataBytes(contents []byte, out interface{}) ([]byte, error) {
 		line := contents[start:end]
 		if isYAMLSeparator(line) {
 			front = contents[frontMatterStart:start]
-			body = contents[end+1:]
+			if end+1 < len(contents) {
+				body = contents[end+1:]
+			}
 			break
 		}
 	}

--- a/modules/markup/markdown/meta_test.go
+++ b/modules/markup/markdown/meta_test.go
@@ -61,7 +61,7 @@ func TestExtractMetadataBytes(t *testing.T) {
 		var meta structs.IssueTemplate
 		body, err := ExtractMetadataBytes([]byte(fmt.Sprintf("%s\n%s\n%s\n%s", sepTest, frontTest, sepTest, bodyTest)), &meta)
 		assert.NoError(t, err)
-		assert.Equal(t, bodyTest, body)
+		assert.Equal(t, bodyTest, string(body))
 		assert.Equal(t, metaTest, meta)
 		assert.True(t, validateMetadata(meta))
 	})
@@ -82,7 +82,7 @@ func TestExtractMetadataBytes(t *testing.T) {
 		var meta structs.IssueTemplate
 		body, err := ExtractMetadataBytes([]byte(fmt.Sprintf("%s\n%s\n%s", sepTest, frontTest, sepTest)), &meta)
 		assert.NoError(t, err)
-		assert.Equal(t, "", body)
+		assert.Equal(t, "", string(body))
 		assert.Equal(t, metaTest, meta)
 		assert.True(t, validateMetadata(meta))
 	})

--- a/modules/markup/markdown/renderconfig_test.go
+++ b/modules/markup/markdown/renderconfig_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"code.gitea.io/gitea/modules/util"
 	"gopkg.in/yaml.v3"
 )
 
@@ -82,20 +81,20 @@ func TestRenderConfig_UnmarshalYAML(t *testing.T) {
 				Icon: "table",
 				TOC:  true,
 				Lang: "testlang",
-			}, util.Dedent(`
+			}, `
 				include_toc: true
 				lang: testlang
-				`),
+				`,
 		},
 		{
 			"complexlang", &RenderConfig{
 				Meta: "table",
 				Icon: "table",
 				Lang: "testlang",
-			}, util.Dedent(`
+			}, `
 				gitea:
 					lang: testlang
-				`),
+				`,
 		},
 		{
 			"complexlang2", &RenderConfig{
@@ -142,7 +141,7 @@ func TestRenderConfig_UnmarshalYAML(t *testing.T) {
 				Icon: "table",
 				Lang: "",
 			}
-			if err := yaml.Unmarshal([]byte(strings.ReplaceAll(tt.args, "\t", "        ")), got); err != nil {
+			if err := yaml.Unmarshal([]byte(strings.ReplaceAll(tt.args, "\t", "    ")), got); err != nil {
 				t.Errorf("RenderConfig.UnmarshalYAML() error = %v\n%q", err, tt.args)
 				return
 			}


### PR DESCRIPTION
* Add missing `os.Exit(m.Run())` to `markup/html_test.go` and fix the test in `TestRender_emoji`
* Fix a overflow bug in  `markup/markdown/meta.go`
* Fix the string vs bytes comparison in `markup/markdown/meta_test.go`
* Remove unnecessary `util.Dedent`, YAML can accept global indention.
